### PR TITLE
Fix: Corrected conditional rendering logic for services text

### DIFF
--- a/src/components/AboutUs.tsx
+++ b/src/components/AboutUs.tsx
@@ -1,10 +1,7 @@
 'use client'
 
 import { cn } from "@/utils";
-import { Button, Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
-import { XMarkIcon } from "@heroicons/react/24/outline";
-import { ChevronRightIcon } from "@heroicons/react/24/solid";
-import { ChevronLeftIcon } from "@heroicons/react/24/solid";
+import { Button } from "@headlessui/react";
 import { type FC, KeyboardEvent, useState } from "react";
 import { ImageViewer } from "./ImageViewer";
 import { NumberCounter } from "./NumberCounter";
@@ -107,7 +104,7 @@ export const AboutUs: FC = () => {
 						</p>
 						<p className="mt-8 text-base/7 text-gray-600">
 							{expandedServices ? servicesTextExpanded : servicesTextCollapsed}
-							<Button type='button' onClick={toggleServices} className='text-indigo-500 hover:text-indigo-700 focus:outline-none'>{expandedMission ? ' Less' : ' More'}</Button>
+							<Button type='button' onClick={toggleServices} className='text-indigo-500 hover:text-indigo-700 focus:outline-none'>{expandedServices ? ' Less' : ' More'}</Button>
 						</p>
 					</div>
 					<div className="pt-16 lg:row-span-2 lg:-mr-16 xl:mr-auto">

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -136,15 +136,15 @@ export const ServiceCard: FC<{ service: ServiceCardData; index: number }> = ({
 
 						{/* Back of card */}
 						<div
-							className="absolute w-full h-full rounded-lg bg-teal-900 shadow-md"
+							className="absolute w-full h-full rounded-lg bg-moving-gray shadow-md"
 							style={{
 								backfaceVisibility: "hidden",
 								transform: "rotateY(180deg)",
 							}}
 						>
-							<div className="flex h-full flex-col justify-center p-6 text-teal-100">
-								<h3 className="text-xl font-semibold mb-3">{service.title}</h3>
-								<p className="text-sm opacity-90">{service.description}</p>
+							<div className="flex h-full flex-col justify-center p-6">
+								<h3 className="text-xl font-semibold mb-3 text-white">{service.title}</h3>
+								<p className="text-sm opacity-90 text-gray-200">{service.description}</p>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
Corrected the conditional rendering logic for the "More/Less" button in the AboutUs component to correctly toggle the display of expanded or collapsed services text.

Updated the background color of the back of the service card to moving-gray and the text color to white and gray-200.