### PR TITLE
Add truck icon for city markers on map

### DIFF
--- a/src/components/LeafletMap.tsx
+++ b/src/components/LeafletMap.tsx
@@ -13,7 +13,7 @@ import { XMarkIcon } from "@heroicons/react/24/solid"
 import { Button } from "@headlessui/react"
 import { cn } from "@/utils"
 import { useMap } from 'react-leaflet'
-import { Icon } from 'leaflet'
+import { Icon, divIcon } from 'leaflet'
 import { useEffect } from 'react'
 
 
@@ -22,7 +22,6 @@ export type LeafletMapProps = Pick<MapCitiesProps, 'selectedCity' | 'onSelectCit
 	mapCenter: LatLngExpression
 	mapZoom: number
 	mapStyleIndex: number
-
 	mapRef: any
 	onMapStyleChange: (index: number) => void
 	onToggleStyleSelector: VoidFunction
@@ -35,8 +34,6 @@ const TileLayer = dynamic(() => import('react-leaflet').then(map => map.TileLaye
 const ZoomControl = dynamic(() => import('react-leaflet').then(map => map.ZoomControl), { ssr: false })
 const Marker = dynamic(() => import('react-leaflet').then(map => map.Marker), { ssr: false })
 const Popup = dynamic(() => import('react-leaflet').then(map => map.Popup), { ssr: false })
-// const useMap = dynamic(() => import('react-leaflet').then(mod => mod.useMap), { ssr: false })
-
 
 
 export const MapIcon = new Icon({
@@ -48,6 +45,15 @@ export const MapIcon = new Icon({
 	popupAnchor: [1, -34],
 	shadowSize: [41, 41]
 });
+
+const TruckMapIcon = divIcon({
+	html: `<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000" class="size-6">
+  			<path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 0 1-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 0 0-3.213-9.193 2.056 2.056 0 0 0-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 0 0-10.026 0 1.106 1.106 0 0 0-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12" />
+     		</svg>`,
+	className: 'text-yellow-400',
+	iconSize: [20, 20],
+	iconAnchor: [12, 20]
+})
 
 export const LeafletMap: FC<LeafletMapProps> = ({ mapCenter, mapZoom, mapRef, mapStyleIndex, cities, hoveredCity, showStyleSelector, onSelectCity, onToggleStyleSelector, onMapStyleChange }) => {
 
@@ -75,7 +81,7 @@ export const LeafletMap: FC<LeafletMapProps> = ({ mapCenter, mapZoom, mapRef, ma
 					<Marker
 						key={city.href}
 						position={[city.latitude, city.longitude]}
-						icon={MapIcon}
+						icon={TruckMapIcon}
 						eventHandlers={{
 							click: () => onSelectCity(city.city),
 						}}


### PR DESCRIPTION
Replaces the default map marker with a truck icon to better represent the delivery focus of the application.