### PR TITLE
Refactor service areas to use CMS data

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
 	"name": "pmoving-services",
 	"version": "0.1.0",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "next dev --turbopack",
 		"build": "next build",
 		"start": "next start",
 		"lint": "biome lint --error-on-warnings ./src",
 		"lint:fix": "biome lint --write ./src",
-		"format": "biome format --write ./src"
+		"format": "biome format --write ./src",
+		"generate:types": "PAYLOAD_CONFIG_PATH=src/payload.config.ts payload generate:types"
 	},
 	"dependencies": {
 		"@headlessui/react": "^2.2.0",

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,1 +1,5 @@
-export const importMap = {};
+
+
+export const importMap = {
+
+}

--- a/src/collections/ServiceAreas.ts
+++ b/src/collections/ServiceAreas.ts
@@ -6,22 +6,27 @@ export const ServiceArea: CollectionConfig = {
 		{
 			name: "title",
 			type: "text",
+			required: true,
 		},
 		{
 			name: "description",
 			type: "text",
+			required: true,
 		},
 		{
 			name: "short-code",
 			type: "text",
+			required: true,
 		},
 		{
 			name: "latitude",
 			type: "number",
+			required: true,
 		},
 		{
 			name: "longitude",
 			type: "number",
+			required: true,
 		},
 		{
 			name: "state-name",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,27 +1,21 @@
-"use client";
 
-import { type FC, useState } from "react";
+
+import { type FC } from "react";
 import {
-	Dialog,
-	DialogPanel,
-	Disclosure,
-	DisclosureButton,
-	DisclosurePanel,
 	PopoverGroup,
 	Button,
 } from "@headlessui/react";
-import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
-import { ChevronDownIcon } from "@heroicons/react/20/solid";
-import { callsToAction, services, Services } from "./Services";
+import { Services } from "./Services";
 import Link from "next/link";
-import { moverLinks, ServiceArea } from "./ServiceAreas";
 import { SunIcon } from "@heroicons/react/24/solid";
-import { cn } from "@/utils";
-import { socialMediaLinks } from "./Banner";
-import { PhoneIcon } from "@heroicons/react/24/outline";
+import { MobileSidebar } from "./MobileSidebar";
+import { getServiceAreas } from "@/data/service-areas";
+import { ServiceArea } from "./ServiceAreas";
 
-export const Header: FC = () => {
-	const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+export const Header: FC = async () => {
+
+	const areas = await getServiceAreas()
 
 	return (
 		<section className="bg-moving-gray sm:mt-12 w-full z-50">
@@ -40,22 +34,11 @@ export const Header: FC = () => {
 					</Link>
 				</div>
 				<div className="flex lg:hidden">
-					<Button
-						type="button"
-						onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-						className="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-white"
-					>
-						<span className="sr-only">Open main menu</span>
-						{mobileMenuOpen ? (
-							<XMarkIcon aria-hidden="true" className="size-6" />
-						) : (
-							<Bars3Icon aria-hidden="true" className="size-6" />
-						)}
-					</Button>
+					<MobileSidebar areas={areas.docs} />
 				</div>
 				<PopoverGroup className="hidden z-[100] lg:flex lg:gap-x-12">
 					<Services />
-					<ServiceArea links={moverLinks} />
+					<ServiceArea links={areas.docs} />
 					<Link href="/blog" className="text-sm/6 font-semibold text-white">
 						Blog
 					</Link>
@@ -68,7 +51,6 @@ export const Header: FC = () => {
 					>
 						Frequently Asked Questions
 					</Link>
-					"
 				</PopoverGroup>
 
 				{/* Replace block with a lightmode, darkmode toggle */}
@@ -78,151 +60,7 @@ export const Header: FC = () => {
 					</Button>
 				</div>
 			</nav>
-			<Dialog
-				open={mobileMenuOpen}
-				onClose={setMobileMenuOpen}
-				className="lg:hidden"
-			>
-				<div className="fixed inset-0 z-10" />
-				<DialogPanel className="fixed inset-y-0 right-0 z-10 w-full overflow-y-auto bg-moving-gray px-6 py-6 sm:max-w-sm sm:ring-1 sm:ring-gray-900/10 transition-transform duration-300 ease-in-out transform translate-x-0">
-					<div className="flex items-center justify-between">
-						<Link href="/" className="-m-1.5 p-1.5">
-							<span className="sr-only">P Moving Services</span>
-							<img
-								alt="Premium Moving Services Logo"
-								src="/logo.svg"
-								className="h-8 w-auto"
-							/>
-						</Link>
-						<Button
-							type="button"
-							onClick={() => setMobileMenuOpen(false)}
-							className="-m-2.5 rounded-md p-2.5 hover:bg-moving-gray/50"
-						>
-							<span className="sr-only">Close menu</span>
-							<XMarkIcon aria-hidden="true" className="size-6 stroke-white" />
-						</Button>
-					</div>
-					<div className="mt-6 flow-root">
-						<div className="-my-6 divide-y divide-gray-500/10">
-							<div className="space-y-2 py-6">
-								<Disclosure as="div" className="-mx-3">
-									<DisclosureButton className="group flex w-full items-center justify-between rounded-lg py-2 pr-3.5 pl-3 text-base/7 font-semibold text-white hover:bg-white hover:text-gray-900">
-										Services
-										<ChevronDownIcon
-											aria-hidden="true"
-											className="size-5 flex-none group-data-open:rotate-180"
-										/>
-									</DisclosureButton>
-									<DisclosurePanel className="mt-2 space-y-2">
-										{[...services, ...callsToAction].map((item, index) => (
-											<DisclosureButton
-												key={item.name}
-												as="a"
-												href={item.href}
-												title={`Go to ${item.name} page`}
-												className="group inline-flex items-center justify-center gap-x-1.5 rounded-lg py-2 pr-3 pl-6 text-sm/7 font-semibold text-gray-200 hover:bg-white/10 focus-visible:outline-none focus-visible:bg-moving-gray/80 focus:bg-moving-gray/10"
-											>
-												<item.icon
-													aria-hidden="true"
-													className={cn(
-														"size-5 stroke-moving-yellow",
-														index > 3 &&
-															"stroke-inherit group-hover:animate-fill-both fill-moving-yellow",
-														index === 2 && "hover:animate-shake",
-													)}
-												/>
-												{index === 5 ? "Find us on the map" : item.name}
-											</DisclosureButton>
-										))}
-									</DisclosurePanel>
-								</Disclosure>
-								<a
-									href="/blog"
-									className="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-white hover:text-gray-700 hover:bg-gray-50"
-								>
-									Blog
-								</a>
-								<a
-									href="/#faqs"
-									className="-mx-3 block scroll-smooth rounded-lg px-3 py-2 text-base/7 font-semibold text-white hover:text-gray-700 hover:bg-gray-50"
-								>
-									Frequently Asked Questions
-								</a>
-								<Link
-									href="/careers"
-									className="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-white hover:text-gray-700 hover:bg-gray-50"
-								>
-									Careers
-								</Link>
 
-								<Disclosure as="div" className="-mx-3">
-									<DisclosureButton className="group flex w-full items-center justify-between rounded-lg py-2 pr-3.5 pl-3 text-base/7 font-semibold text-white hover:bg-white hover:text-gray-900">
-										Serivce Areas
-										<ChevronDownIcon
-											aria-hidden="true"
-											className="h-5 w-5 flex-none group-data-[open]:rotate-180"
-										/>
-									</DisclosureButton>
-									<DisclosurePanel className="mt-2 space-y-2">
-										{moverLinks
-											.sort((a, b) =>
-												a.city.toLowerCase() > b.city.toLowerCase() ? 1 : -1,
-											)
-											.map((item) => (
-												<DisclosureButton
-													key={item.href}
-													as="a"
-													href={item.href}
-													className="block rounded-lg py-2 pl-6 pr-3 text-sm font-semibold leading-7 text-gray-300 hover:text-gray-100 hover:bg-white/10"
-												>
-													<div className="group w-full inline-flex items-center justify-between">
-														<span>{item.city}</span>
-														<span className="hidden rounded-lg text-sm p-1 font-normal shadow-sm ring-gray-white/50 group-focus:inline group-hover:inline text-gray-200">
-															{item.state}
-														</span>
-													</div>
-												</DisclosureButton>
-											))}
-									</DisclosurePanel>
-								</Disclosure>
-							</div>
-							<div className="flex justify-start w-full border-t border-solid border-gray-300 gap-4 py-6">
-								{socialMediaLinks.map((link, index) => (
-									<Link
-										key={link.href}
-										href={link.href}
-										title={link.name}
-										target="_blank"
-										className=""
-									>
-										<span className="sr-only">{link.name}</span>
-										<link.icon
-											className={cn(
-												"size-5 fill-white",
-												index === 4 && "stroke-white",
-											)}
-											aria-hidden="true"
-										/>
-									</Link>
-								))}
-								<Link
-									href="tel:651-757-5135"
-									title="call us"
-									target="_blank"
-									className=""
-								>
-									<span className="sr-only">Call</span>
-									<PhoneIcon
-										className={cn("size-5 rotate-x-45 fill-white stroke-white")}
-										aria-hidden="true"
-									/>
-								</Link>
-							</div>
-						</div>
-					</div>
-				</DialogPanel>
-			</Dialog>
 		</section>
 	);
 };

--- a/src/components/MobileSidebar.tsx
+++ b/src/components/MobileSidebar.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { ChevronDownIcon } from "@heroicons/react/20/solid";
+import { callsToAction, services } from "./Services";
+import Link from "next/link";
+import { cn } from "@/utils";
+import { socialMediaLinks } from "./Banner";
+import { PhoneIcon } from "@heroicons/react/24/outline";
+import { Dialog, DialogPanel, Disclosure, DisclosureButton, DisclosurePanel, Button } from "@headlessui/react";
+import { XMarkIcon, Bars3Icon } from "@heroicons/react/24/outline";
+import { FC, useState } from "react";
+import { ServiceAreaType } from "@/types";
+
+
+export interface MobileSidebarProps {
+	areas: ServiceAreaType[]
+}
+
+export const MobileSidebar: FC<MobileSidebarProps> = ({ areas }) => {
+
+	const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+	return (
+		<>
+			<Button
+				type="button"
+				onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+				className="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-white"
+			>
+				<span className="sr-only">Open main menu</span>
+				{mobileMenuOpen ? (
+					<XMarkIcon aria-hidden="true" className="size-6" />
+				) : (
+					<Bars3Icon aria-hidden="true" className="size-6" />
+				)}
+			</Button>
+			<Dialog
+				open={mobileMenuOpen}
+				onClose={setMobileMenuOpen}
+				className="lg:hidden"
+			>
+				<div className="fixed inset-0 z-10" />
+				<DialogPanel className="fixed inset-y-0 right-0 z-10 w-full overflow-y-auto bg-moving-gray px-6 py-6 sm:max-w-sm sm:ring-1 sm:ring-gray-900/10 transition-transform duration-300 ease-in-out transform translate-x-0">
+					<div className="flex items-center justify-between">
+						<Link href="/" className="-m-1.5 p-1.5">
+							<span className="sr-only">P Moving Services</span>
+							<img
+								alt="Premium Moving Services Logo"
+								src="/logo.svg"
+								className="h-8 w-auto"
+							/>
+						</Link>
+						<Button
+							type="button"
+							onClick={() => setMobileMenuOpen(false)}
+							className="-m-2.5 rounded-md p-2.5 hover:bg-moving-gray/50"
+						>
+							<span className="sr-only">Close menu</span>
+							<XMarkIcon aria-hidden="true" className="size-6 stroke-white" />
+						</Button>
+					</div>
+					<div className="mt-6 flow-root">
+						<div className="-my-6 divide-y divide-gray-500/10">
+							<div className="space-y-2 py-6">
+								<Disclosure as="div" className="-mx-3">
+									<DisclosureButton className="group flex w-full items-center justify-between rounded-lg py-2 pr-3.5 pl-3 text-base/7 font-semibold text-white hover:bg-white hover:text-gray-900">
+										Services
+										<ChevronDownIcon
+											aria-hidden="true"
+											className="size-5 flex-none group-data-open:rotate-180"
+										/>
+									</DisclosureButton>
+									<DisclosurePanel className="mt-2 space-y-2">
+										{[...services, ...callsToAction].map((item, index) => (
+											<DisclosureButton
+												key={item.name}
+												as="a"
+												href={item.href}
+												title={`Go to ${item.name} page`}
+												className="group inline-flex items-center justify-center gap-x-1.5 rounded-lg py-2 pr-3 pl-6 text-sm/7 font-semibold text-gray-200 hover:bg-white/10 focus-visible:outline-none focus-visible:bg-moving-gray/80 focus:bg-moving-gray/10"
+											>
+												<item.icon
+													aria-hidden="true"
+													className={cn(
+														"size-5 stroke-moving-yellow",
+														index > 3 &&
+														"stroke-inherit group-hover:animate-fill-both fill-moving-yellow",
+														index === 2 && "hover:animate-shake",
+													)}
+												/>
+												{index === 5 ? "Find us on the map" : item.name}
+											</DisclosureButton>
+										))}
+									</DisclosurePanel>
+								</Disclosure>
+								<a
+									href="/blog"
+									className="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-white hover:text-gray-700 hover:bg-gray-50"
+								>
+									Blog
+								</a>
+								<a
+									href="/#faqs"
+									className="-mx-3 block scroll-smooth rounded-lg px-3 py-2 text-base/7 font-semibold text-white hover:text-gray-700 hover:bg-gray-50"
+								>
+									Frequently Asked Questions
+								</a>
+								<Link
+									href="/careers"
+									className="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-white hover:text-gray-700 hover:bg-gray-50"
+								>
+									Careers
+								</Link>
+
+								<Disclosure as="div" className="-mx-3">
+									<DisclosureButton className="group flex w-full items-center justify-between rounded-lg py-2 pr-3.5 pl-3 text-base/7 font-semibold text-white hover:bg-white hover:text-gray-900">
+										Serivce Areas
+										<ChevronDownIcon
+											aria-hidden="true"
+											className="h-5 w-5 flex-none group-data-[open]:rotate-180"
+										/>
+									</DisclosureButton>
+									<DisclosurePanel className="mt-2 space-y-2">
+										{areas.map((area) => (
+											<DisclosureButton
+												key={area.id}
+												as="a"
+												href={`/service-areas/${area["short-code"]}`}
+												className="block rounded-lg py-2 pl-6 pr-3 text-sm font-semibold leading-7 text-gray-300 hover:text-gray-100 hover:bg-white/10"
+											>
+												<div className="group capitalize w-full inline-flex items-center justify-between">
+													<span>{area.title}</span>
+													<span className="hidden rounded-lg text-sm p-1 font-normal shadow-sm ring-gray-white/50 group-focus:inline group-hover:inline text-gray-200">
+														{area["state-initials"].toUpperCase()}
+													</span>
+												</div>
+											</DisclosureButton>
+										))}
+									</DisclosurePanel>
+								</Disclosure>
+							</div>
+							<div className="flex justify-start w-full border-t border-solid border-gray-300 gap-4 py-6">
+								{socialMediaLinks.map((link, index) => (
+									<Link
+										key={link.href}
+										href={link.href}
+										title={link.name}
+										target="_blank"
+										className=""
+									>
+										<span className="sr-only">{link.name}</span>
+										<link.icon
+											className={cn(
+												"size-5 fill-white",
+												index === 4 && "stroke-white",
+											)}
+											aria-hidden="true"
+										/>
+									</Link>
+								))}
+								<Link
+									href="tel:651-757-5135"
+									title="call us"
+									target="_blank"
+									className=""
+								>
+									<span className="sr-only">Call</span>
+									<PhoneIcon
+										className={cn("size-5 rotate-x-45 fill-white stroke-white")}
+										aria-hidden="true"
+									/>
+								</Link>
+							</div>
+						</div>
+					</div>
+				</DialogPanel>
+			</Dialog>
+		</>
+	)
+}

--- a/src/components/ServiceAreas.tsx
+++ b/src/components/ServiceAreas.tsx
@@ -1,4 +1,7 @@
 "use client";
+
+
+import { ServiceAreaType } from "@/types";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/16/solid";
 import Link from "next/link";
@@ -12,267 +15,8 @@ export type MoverLink = {
 	subLinks?: MoverLink[];
 };
 
-export const moverLinks: MoverLink[] = [
-	{
-		href: "/albert-lea--mn",
-		linkText: "Albert Lea Movers, MN",
-		city: "Albert Lea",
-		state: "MN",
-	},
-	{
-		href: "/movers-eagan--mn",
-		linkText: "Eagan Movers, MN",
-		city: "Eagan",
-		state: "MN",
-	},
-	{
-		href: "/elk-river--mn",
-		linkText: "Elk River Movers, MN",
-		city: "Elk River",
-		state: "MN",
-	},
-	{
-		href: "/movers-forest-lake--mn",
-		linkText: "Forest Lake Movers, MN",
-		city: "Forest Lake",
-		state: "MN",
-	},
-	{
-		href: "/movers-faribault--mn",
-		linkText: "Faribault Movers, MN",
-		city: "Faribault",
-		state: "MN",
-	},
-	{
-		href: "/movers-west-saint-paul-mn",
-		linkText: "West Saint Paul Movers, MN",
-		city: "West Saint Paul",
-		state: "MN",
-	},
-	{
-		href: "/movers-st-paul-mn",
-		linkText: "St. Paul Movers, MN",
-		city: "St. Paul",
-		state: "MN",
-	},
-	{
-		href: "/movers-south-saint-paul-mn",
-		linkText: "South Saint Paul Movers, MN",
-		city: "South Saint Paul",
-		state: "MN",
-	},
-	{
-		href: "https://maps.app.goo.gl/zLxSoiVUKsYDpExC7",
-		linkText: "Shoreview Movers, MN",
-		city: "Shoreview",
-		state: "MN",
-	},
-	{
-		href: "/movers-st-cloud--mn",
-		linkText: "St. Cloud Movers, MN",
-		city: "St. Cloud",
-		state: "MN",
-	},
-	{
-		href: "/movers-stewartville--mn",
-		linkText: "Stewartville Movers, MN",
-		city: "Stewartville",
-		state: "MN",
-	},
-	{
-		href: "/movers-mendota-heights-mn",
-		linkText: "Mendota Heights Movers, MN",
-		city: "Mendota Heights",
-		state: "MN",
-	},
-	{
-		href: "/movers-maplewood-mn",
-		linkText: "Maplewood Movers, MN",
-		city: "Maplewood",
-		state: "MN",
-	},
-	{
-		href: "/movers-little-canada-mn",
-		linkText: "Little Canada Movers, MN",
-		city: "Little Canada",
-		state: "MN",
-	},
-	{
-		href: "/movers-oakdale-mn",
-		linkText: "Oakdale Movers, MN",
-		city: "Oakdale",
-		state: "MN",
-	},
-	{
-		href: "/movers-woodbury-mn",
-		linkText: "Woodbury Movers, MN",
-		city: "Woodbury",
-		state: "MN",
-	},
-	{
-		href: "/movers-north-saint-paul-mn",
-		linkText: "North Saint Paul Movers, MN",
-		city: "North Saint Paul",
-		state: "MN",
-	},
-	{
-		href: "/movers-inver-grove-heights",
-		linkText: "Inver Grove Heights Movers, MN",
-		city: "Inver Grove Heights",
-		state: "MN",
-	},
-	{
-		href: "/movers-northfield--mn",
-		linkText: "Northfield Movers, MN",
-		city: "Northfield",
-		state: "MN",
-	},
-	{
-		href: "/movers-new-brighton-mn",
-		linkText: "New Brighton Movers, MN",
-		city: "New Brighton",
-		state: "MN",
-	},
-	{
-		href: "/movers-new-prague--mn",
-		linkText: "New Prague Movers, MN",
-		city: "New Prague",
-		state: "MN",
-	},
-	{
-		href: "/movers-vadnais-heights-mn",
-		linkText: "Vadnais Heights Movers, MN",
-		city: "Vadnais Heights",
-		state: "MN",
-	},
-	{
-		href: "/movers-ramsey-county",
-		linkText: "Ramsey County Movers, MN",
-		city: "Ramsey County",
-		state: "MN",
-	},
-	{
-		href: "/movers-twin-cities",
-		linkText: "Twin Cities Movers",
-		city: "Twin Cities",
-		state: "MN",
-	},
-	{
-		href: "/movers-hennepin-county",
-		linkText: "Hennepin County Movers",
-		city: "Hennepin County",
-		state: "MN",
-	},
-	{
-		href: "/movers-minneapolis-mn",
-		linkText: "Minneapolis Movers, MN",
-		city: "Minneapolis",
-		state: "MN",
-	},
-	{
-		href: "/movers-mankota--mn",
-		linkText: "Mankota Movers, MN",
-		city: "Mankota",
-		state: "MN",
-	},
-	{
-		href: "/movers-north-oaks--mn668c5293",
-		linkText: "North Oaks Movers, MN",
-		city: "North Oaks",
-		state: "MN",
-	},
-	{
-		href: "/white-bear-lake",
-		linkText: "White Bear Lake Movers, MN",
-		city: "White Bear Lake",
-		state: "MN",
-	},
-	{
-		href: "/movers-richfield-mn",
-		linkText: "Richfield Movers, MN",
-		city: "Richfield",
-		state: "MN",
-	},
-	{
-		href: "/movers-roseville-mn",
-		linkText: "Roseville Movers, MN",
-		city: "Roseville",
-		state: "MN",
-	},
-	{
-		href: "/lakeville-movers-mn",
-		linkText: "Lakeville Movers, MN",
-		city: "Lakeville",
-		state: "MN",
-	},
-	{
-		href: "/movers-burnsville-mn",
-		linkText: "Burnsville Movers, MN",
-		city: "Burnsville",
-		state: "MN",
-	},
-	{
-		href: "/movers-austin-mn",
-		linkText: "Austin Movers, MN",
-		city: "Austin",
-		state: "MN",
-	},
-	{
-		href: "/movers-otsego--mn",
-		linkText: "Otsego Movers, MN",
-		city: "Otsego",
-		state: "MN",
-	},
-	{
-		href: "/movers-owatonna--mn",
-		linkText: "Owatonna Movers, MN",
-		city: "Owatonna",
-		state: "MN",
-	},
-	{
-		href: "/movers-wayzata--mn",
-		linkText: "Wayzata Movers, MN",
-		city: "Wayzata",
-		state: "MN",
-	},
-	{
-		href: "/movers-winona--mn",
-		linkText: "Winona Movers, MN",
-		city: "Winona",
-		state: "MN",
-	},
-	{
-		href: "/movers-rochester--mn",
-		linkText: "Rochester Movers, MN",
-		city: "Rochester",
-		state: "MN",
-	},
-	{
-		href: "/movers-rogers--mn",
-		linkText: "Rogers Movers, MN",
-		city: "Rogers",
-		state: "MN",
-	},
-	{
-		href: "/movers-river-falls--wi",
-		linkText: "River Falls Movers, WI",
-		city: "River Falls",
-		state: "WI",
-	},
-	{
-		href: "/movers-prescott--wi",
-		linkText: "Prescott Movers, WI",
-		city: "Prescott",
-		state: "WI",
-	},
-];
 
-// TODO: This is what i'm currently working on.
-// Could not complete but still have to push
-export const ServiceArea: FC<{ links: MoverLink[] }> = ({ links }) => {
-	const alpabeticalLinks = links.sort((a, b) =>
-		a.city.toLowerCase() > b.city.toLowerCase() ? 1 : -1,
-	);
+export const ServiceArea: FC<{ links: ServiceAreaType[] }> = ({ links }) => {
 
 	return (
 		<div className="z-[99]">
@@ -293,17 +37,17 @@ export const ServiceArea: FC<{ links: MoverLink[] }> = ({ links }) => {
 				<MenuItems
 					transition
 					anchor="bottom"
-					className="w-56 h-1/2 max-h-80 z-[99] overflow-y-scroll origin-top-right text-gray-700 rounded-xl border-none ring-1 shadow-sm ring-gray-200 bg-white p-1 text-sm/6 transition duration-100 ease-out [--anchor-gap:8px] focus:outline-none data-[closed]:scale-95 data-[closed]:opacity-0"
+					className="w-56 h-auto max-h-80 z-[99] overflow-y-scroll origin-top-right text-gray-700 rounded-xl border-none ring-1 shadow-sm ring-gray-200 bg-white p-1 text-sm/6 transition duration-100 ease-out [--anchor-gap:8px] focus:outline-none data-[closed]:scale-95 data-[closed]:opacity-0"
 				>
-					{alpabeticalLinks.map((link) => (
-						<MenuItem key={link.href}>
+					{links.map((link) => (
+						<MenuItem key={link.id}>
 							<Link
-								href={link.href}
+								href={`/service-areas/${link["short-code"]}`}
 								className="group capitalize flex w-full text-gray-700 hover:bg-gray-100 hover:text-gray-900 items-center gap-2 rounded-xl truncate py-1.5 px-3"
 							>
-								{link.city}
+								{link.title?.toLowerCase() ?? ''}
 								<span className="ml-auto hidden font-sans text-sm text-gray-500 group-data-[hover]:inline group-data-[focus]:inline">
-									{link.state.toUpperCase()}
+									{link["state-initials"]?.toUpperCase()}
 								</span>
 							</Link>
 						</MenuItem>

--- a/src/data/service-areas.ts
+++ b/src/data/service-areas.ts
@@ -1,0 +1,10 @@
+import config from '@payload-config'
+import { getPayload } from 'payload'
+
+export async function getServiceAreas() {
+	const payload = await getPayload({ config });
+	return await payload.find({ collection: 'service-areas', pagination: false })
+}
+
+
+export type ServiceAreasType = Awaited<ReturnType<typeof getServiceAreas>>

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -6,121 +6,323 @@
  * and re-run `payload generate:types` to regenerate this file.
  */
 
+/**
+ * Supported timezones in IANA format.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "supportedTimezones".
+ */
+export type SupportedTimezones =
+  | 'Pacific/Midway'
+  | 'Pacific/Niue'
+  | 'Pacific/Honolulu'
+  | 'Pacific/Rarotonga'
+  | 'America/Anchorage'
+  | 'Pacific/Gambier'
+  | 'America/Los_Angeles'
+  | 'America/Tijuana'
+  | 'America/Denver'
+  | 'America/Phoenix'
+  | 'America/Chicago'
+  | 'America/Guatemala'
+  | 'America/New_York'
+  | 'America/Bogota'
+  | 'America/Caracas'
+  | 'America/Santiago'
+  | 'America/Buenos_Aires'
+  | 'America/Sao_Paulo'
+  | 'Atlantic/South_Georgia'
+  | 'Atlantic/Azores'
+  | 'Atlantic/Cape_Verde'
+  | 'Europe/London'
+  | 'Europe/Berlin'
+  | 'Africa/Lagos'
+  | 'Europe/Athens'
+  | 'Africa/Cairo'
+  | 'Europe/Moscow'
+  | 'Asia/Riyadh'
+  | 'Asia/Dubai'
+  | 'Asia/Baku'
+  | 'Asia/Karachi'
+  | 'Asia/Tashkent'
+  | 'Asia/Calcutta'
+  | 'Asia/Dhaka'
+  | 'Asia/Almaty'
+  | 'Asia/Jakarta'
+  | 'Asia/Bangkok'
+  | 'Asia/Shanghai'
+  | 'Asia/Singapore'
+  | 'Asia/Tokyo'
+  | 'Asia/Seoul'
+  | 'Australia/Brisbane'
+  | 'Australia/Sydney'
+  | 'Pacific/Guam'
+  | 'Pacific/Noumea'
+  | 'Pacific/Auckland'
+  | 'Pacific/Fiji';
+
 export interface Config {
-	auth: {
-		users: UserAuthOperations;
-	};
-	collections: {
-		users: User;
-		media: Media;
-		"payload-preferences": PayloadPreference;
-		"payload-migrations": PayloadMigration;
-	};
-	db: {
-		defaultIDType: string;
-	};
-	globals: {};
-	locale: null;
-	user: User & {
-		collection: "users";
-	};
+  auth: {
+    users: UserAuthOperations;
+  };
+  blocks: {};
+  collections: {
+    users: User;
+    media: Media;
+    'service-areas': ServiceArea;
+    'payload-locked-documents': PayloadLockedDocument;
+    'payload-preferences': PayloadPreference;
+    'payload-migrations': PayloadMigration;
+  };
+  collectionsJoins: {};
+  collectionsSelect: {
+    users: UsersSelect<false> | UsersSelect<true>;
+    media: MediaSelect<false> | MediaSelect<true>;
+    'service-areas': ServiceAreasSelect<false> | ServiceAreasSelect<true>;
+    'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
+    'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
+    'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
+  };
+  db: {
+    defaultIDType: number;
+  };
+  globals: {};
+  globalsSelect: {};
+  locale: null;
+  user: User & {
+    collection: 'users';
+  };
+  jobs: {
+    tasks: unknown;
+    workflows: unknown;
+  };
 }
 export interface UserAuthOperations {
-	forgotPassword: {
-		email: string;
-		password: string;
-	};
-	login: {
-		email: string;
-		password: string;
-	};
-	registerFirstUser: {
-		email: string;
-		password: string;
-	};
-	unlock: {
-		email: string;
-		password: string;
-	};
+  forgotPassword: {
+    email: string;
+    password: string;
+  };
+  login: {
+    email: string;
+    password: string;
+  };
+  registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
+    email: string;
+    password: string;
+  };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
-	id: string;
-	updatedAt: string;
-	createdAt: string;
-	email: string;
-	resetPasswordToken?: string | null;
-	resetPasswordExpiration?: string | null;
-	salt?: string | null;
-	hash?: string | null;
-	loginAttempts?: number | null;
-	lockUntil?: string | null;
-	password?: string | null;
+  id: number;
+  updatedAt: string;
+  createdAt: string;
+  email: string;
+  resetPasswordToken?: string | null;
+  resetPasswordExpiration?: string | null;
+  salt?: string | null;
+  hash?: string | null;
+  loginAttempts?: number | null;
+  lockUntil?: string | null;
+  password?: string | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "media".
  */
 export interface Media {
-	id: string;
-	alt: string;
-	updatedAt: string;
-	createdAt: string;
-	url?: string | null;
-	thumbnailURL?: string | null;
-	filename?: string | null;
-	mimeType?: string | null;
-	filesize?: number | null;
-	width?: number | null;
-	height?: number | null;
-	focalX?: number | null;
-	focalY?: number | null;
+  id: number;
+  alt: string;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "service-areas".
+ */
+export interface ServiceArea {
+  id: number;
+  title: string;
+  description: string;
+  'short-code': string;
+  latitude: number;
+  longitude: number;
+  /**
+   * What state does this service area or city belong to?
+   */
+  'state-name': string;
+  /**
+   * The two-letter word initials of the state this service area or city belongs to. Example if city is Minnesota, state initials should be MN
+   */
+  'state-initials': string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-locked-documents".
+ */
+export interface PayloadLockedDocument {
+  id: number;
+  document?:
+    | ({
+        relationTo: 'users';
+        value: number | User;
+      } | null)
+    | ({
+        relationTo: 'media';
+        value: number | Media;
+      } | null)
+    | ({
+        relationTo: 'service-areas';
+        value: number | ServiceArea;
+      } | null);
+  globalSlug?: string | null;
+  user: {
+    relationTo: 'users';
+    value: number | User;
+  };
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-	id: string;
-	user: {
-		relationTo: "users";
-		value: string | User;
-	};
-	key?: string | null;
-	value?:
-		| {
-				[k: string]: unknown;
-		  }
-		| unknown[]
-		| string
-		| number
-		| boolean
-		| null;
-	updatedAt: string;
-	createdAt: string;
+  id: number;
+  user: {
+    relationTo: 'users';
+    value: number | User;
+  };
+  key?: string | null;
+  value?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-	id: string;
-	name?: string | null;
-	batch?: number | null;
-	updatedAt: string;
-	createdAt: string;
+  id: number;
+  name?: string | null;
+  batch?: number | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "users_select".
+ */
+export interface UsersSelect<T extends boolean = true> {
+  updatedAt?: T;
+  createdAt?: T;
+  email?: T;
+  resetPasswordToken?: T;
+  resetPasswordExpiration?: T;
+  salt?: T;
+  hash?: T;
+  loginAttempts?: T;
+  lockUntil?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "media_select".
+ */
+export interface MediaSelect<T extends boolean = true> {
+  alt?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "service-areas_select".
+ */
+export interface ServiceAreasSelect<T extends boolean = true> {
+  title?: T;
+  description?: T;
+  'short-code'?: T;
+  latitude?: T;
+  longitude?: T;
+  'state-name'?: T;
+  'state-initials'?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-locked-documents_select".
+ */
+export interface PayloadLockedDocumentsSelect<T extends boolean = true> {
+  document?: T;
+  globalSlug?: T;
+  user?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-preferences_select".
+ */
+export interface PayloadPreferencesSelect<T extends boolean = true> {
+  user?: T;
+  key?: T;
+  value?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-migrations_select".
+ */
+export interface PayloadMigrationsSelect<T extends boolean = true> {
+  name?: T;
+  batch?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "auth".
  */
 export interface Auth {
-	[k: string]: unknown;
+  [k: string]: unknown;
 }
 
-declare module "payload" {
-	export interface GeneratedTypes extends Config {}
+
+declare module 'payload' {
+  export interface GeneratedTypes extends Config {}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,18 @@
+export interface ServiceAreaType {
+	id: number;
+	title: string;
+	description: string;
+	'short-code': string;
+	latitude: number;
+	longitude: number;
+	/**
+	 * What state does this service area or city belong to?
+	 */
+	'state-name': string;
+	/**
+	 * The two-letter word initials of the state this service area or city belongs to. Example if city is Minnesota, state initials should be MN
+	 */
+	'state-initials': string;
+	updatedAt: string;
+	createdAt: string;
+}


### PR DESCRIPTION
Convert Header to server component and extract mobile sidebar to client component.
Add type definitions for service areas and fetch them from Payload CMS instead of using hardcoded data.
Set required fields in
ServiceArea collection and add type generation script.